### PR TITLE
Change type of NodeScoreArgs.UnscheduledPods

### DIFF
--- a/service/api/types.go
+++ b/service/api/types.go
@@ -282,7 +282,7 @@ type NodeScoreArgs struct {
 	// Assignments represents the assignment of unscheduled Pods to either an existing Node which is part of the ClusterSnapshot
 	// or it is a winning simulated Node from a previous run.
 	Assignments     []*NodePodAssignment
-	UnscheduledPods []*PodResourceInfo
+	UnscheduledPods []PodResourceInfo
 }
 
 type NodePodAssignment struct {

--- a/service/scorer/scorer.go
+++ b/service/scorer/scorer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	commontypes "github.com/gardener/scaling-advisor/api/common/types"
 	"github.com/gardener/scaling-advisor/service/api"
+	v1 "k8s.io/api/core/v1"
 )
 
 var _ api.NodeScoreSelector = GetNodeScoreSelector
@@ -15,12 +16,12 @@ func GetNodeScoreSelector(nodeScores ...api.NodeScore) int {
 
 var _ api.GetNodeScorer = GetNodeScorer
 
-func GetNodeScorer(scoringStrategy commontypes.NodeScoringStrategy, instancePricing api.InstancePricing) (api.NodeScorer, error) {
+func GetNodeScorer(scoringStrategy commontypes.NodeScoringStrategy, instancePricing api.InstancePricing, weights map[v1.ResourceName]float64) (api.NodeScorer, error) {
 	switch scoringStrategy {
 	case commontypes.LeastCostNodeScoringStrategy:
-		return &LeastCost{instancePricing: instancePricing}, nil
+		return &LeastCost{instancePricing: instancePricing, weights: weights}, nil
 	case commontypes.LeastWasteNodeScoringStrategy:
-		return &LeastWaste{instancePricing: instancePricing}, nil
+		return &LeastWaste{instancePricing: instancePricing, weights: weights}, nil
 	default:
 		return nil, fmt.Errorf("%w: unsupported %q", api.ErrUnsupportedNodeScoringStrategy, scoringStrategy)
 	}
@@ -30,6 +31,7 @@ var _ api.NodeScorer = (*LeastCost)(nil)
 
 type LeastCost struct {
 	instancePricing api.InstancePricing
+	weights         map[v1.ResourceName]float64
 	// TODO
 }
 
@@ -42,6 +44,7 @@ var _ api.NodeScorer = (*LeastWaste)(nil)
 
 type LeastWaste struct {
 	instancePricing api.InstancePricing
+	weights         map[v1.ResourceName]float64
 	// TODO
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR makes the following changes:

1. the type of  `NodeScoreArgs.UnscheduledPods` is changed from `[]*PodResourceInfo` to `[]PodResourceInfo` for compatibility with `NodeScore.UnscheduledPods`.
2. `weights map[ResourceName]float64` has been added as an argument to `GetNodeScorer`



**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
3. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer

```
