### PR TITLE
Change types to introduce data required for NodeScore and NodeScoreSelector

### DIFF
--- a/service/api/types.go
+++ b/service/api/types.go
@@ -264,7 +264,8 @@ type NodeScore struct {
 	Placement       NodePlacementInfo
 	UnscheduledPods []PodResourceInfo
 	// Value is the score value for this Node.
-	Value int
+	Value              int
+	ScaledNodeResource *NodeResourceInfo
 }
 
 type GetNodeScorer func(scoringStrategy commontypes.NodeScoringStrategy, instancePricing InstancePricing, weights map[corev1.ResourceName]float64) (NodeScorer, error)

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -296,6 +296,8 @@ type NodePlacementInfo struct {
 	NodeTemplateName string
 	// InstanceType is the instance type of the Node.
 	InstanceType string
+	// Region is the region of the instance
+	Region string
 	// AvailabilityZone is the availability zone of the node pool.
 	AvailabilityZone string
 }

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -265,7 +265,7 @@ type NodeScore struct {
 	UnscheduledPods []PodResourceInfo
 	// Value is the score value for this Node.
 	Value              int
-	ScaledNodeResource *NodeResourceInfo
+	ScaledNodeResource NodeResourceInfo
 }
 
 type GetNodeScorer func(scoringStrategy commontypes.NodeScoringStrategy, instancePricing InstancePricing, weights map[corev1.ResourceName]float64) (NodeScorer, error)


### PR DESCRIPTION
**What this PR does / why we need it**:

The PR introduces the following:
1. a field `ScaledNodeResource` of type `NodeResourceInfo` to `NodeScore`. This allows the `LeastCost` strategy to access the `Allocatable` of the scaled node.
2. a field `Region` of type `string` to `NodePlacementInfo`. This is required to get the price of an instance based on region in the scoring logic.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
3. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer

```
