### PR TITLE
[FIX] Pass correct struct for advisor server configuration in `cli_test`

### DIFF
--- a/operator/cmd/scalingadvisor/cli/cli_test.go
+++ b/operator/cmd/scalingadvisor/cli/cli_test.go
@@ -59,13 +59,15 @@ func TestLaunchOptions_ValidateAndLoadOperatorConfig(t *testing.T) {
 			name:       "ShouldLoadMinimalScalingAdvisorConfig",
 			configFile: "./testData/basic-operator-config.yaml",
 			want: updateOperatorConfigWithDefaults(&configv1alpha1.ScalingAdvisorConfiguration{
-				Server: commontypes.ServerConfig{
-					HostPort: commontypes.HostPort{
-						Host: "localhost",
-						Port: 9090,
+				Server: configv1alpha1.ScalingAdvisorServerConfiguration{
+					ServerConfig: commontypes.ServerConfig{
+						HostPort: commontypes.HostPort{
+							Host: "localhost",
+							Port: 9090,
+						},
+						KubeConfigPath:   "/tmp/kube-config.yaml",
+						ProfilingEnabled: false,
 					},
-					KubeConfigPath:   "/tmp/kube-config.yaml",
-					ProfilingEnabled: false,
 				},
 			}),
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix compilation failures for `cli_test.go` in `operator` module.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
