### PR TITLE
Add pull-request-target types labeled

### DIFF
--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -6,6 +6,8 @@ on:
       - 'hotfix-**'
       - 'release-**'
   pull_request_target:
+    types:
+      - labeled
 
 jobs:
   build:


### PR DESCRIPTION
**What this PR does / why we need it**:
To enable GHA to checkout a PR branch it is not sufficient to only have
```yaml
on:
  pull_request_target:
```
As per https://gardener.github.io/cc-utils/github_actions.html#example-configuration-for-label-based-trust one needs to add `labeled` so that it can react on `reviewed/ok-to-test` label on a PR.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
None
```
