### PR TITLE
ci: add pr write permission to all jobs running trusted-checkout

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
     steps:
       - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
       - uses: actions/setup-go@v5
@@ -36,6 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
     strategy:
       matrix:
         args:
@@ -56,6 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
     steps:
       - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
       - uses: actions/setup-go@v5
@@ -72,6 +75,3 @@ jobs:
       linter: gosec
       run: make sast-report
       go-version: '1.25'
-
-
-


### PR DESCRIPTION
**What this PR does / why we need it**:
As per the docs, PR write permission is required for all workflows that call `trusted-checkout`
to allow for removing the `trusted-label` (note the **caveat** below)
```
         pull-requests: write # needed so trusted-checkout can remove trusted-label
                              # caveat: also needs to be set for all called workflows
                              # that use trusted-checkout (action)
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
