### PR TITLE
ci: run pull_request_target for non labeled events

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
       - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: "1.25"
       - name: run-build
         run: make tidy && make build
 
@@ -48,7 +48,7 @@ jobs:
       - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: "1.25"
       - name: run-unit-tests
         shell: bash
         run: |
@@ -64,7 +64,7 @@ jobs:
       - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: "1.25"
       - name: run-check
         run: make check
 
@@ -75,4 +75,4 @@ jobs:
     with:
       linter: gosec
       run: make sast-report
-      go-version: '1.25'
+      go-version: "1.25"

--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -3,14 +3,13 @@ on:
   push:
     branches:
       - main
-      - 'hotfix-**'
-      - 'release-**'
+      - "hotfix-**"
+      - "release-**"
   pull_request_target:
-    types:
-      - labeled
 
 jobs:
   build:
+    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'reviewed/ok-to-test' }}
     uses: ./.github/workflows/build.yaml
     with:
       mode: snapshot
@@ -22,6 +21,7 @@ jobs:
       pull-requests: write
 
   component-descriptor:
+    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'reviewed/ok-to-test' }}
     uses: gardener/cc-utils/.github/workflows/post-build.yaml@master
     needs:
       - build


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the `non-release` workflow for PRs only runs on `labeled` events, ignoring others
This PR introduces checks to run the workflow in two cases:
1. If labeled event AND the `reviewed/ok-to-test` label is added (for PRs raised by contributors outside the gardener org)
2. All other events (assumed that the PR author is org member)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Ref: https://gardener.github.io/cc-utils/github_actions.html#example-configuration-for-label-based-trust

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
3. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
